### PR TITLE
Makes handling of useHostPID consistent

### DIFF
--- a/charts/datadog/templates/agent-scc.yaml
+++ b/charts/datadog/templates/agent-scc.yaml
@@ -15,7 +15,7 @@ priority: 10
 # Allow host ports for dsd / trace intake
 allowHostPorts: {{ or .Values.datadog.dogstatsd.useHostPort .Values.datadog.apm.enabled }}
 # Allow host PID for dogstatsd origin detection
-allowHostPID: {{ .Values.datadog.dogstatsd.useHostPID }}
+allowHostPID: {{ or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.dogstatsd.useHostPID }}
 # Allow host network for the CRIO check to reach Prometheus through localhost
 allowHostNetwork: {{ .Values.agents.useHostNetwork }}
 # Allow hostPath for docker / process metrics

--- a/charts/datadog/templates/daemonset.yaml
+++ b/charts/datadog/templates/daemonset.yaml
@@ -77,12 +77,8 @@ spec:
       dnsConfig:
 {{ toYaml .Values.agents.dnsConfig | indent 8 }}
       {{- end }}
-      {{- if .Values.datadog.securityAgent.compliance.enabled }}
+      {{- if or .Values.datadog.securityAgent.compliance.enabled .Values.datadog.dogstatsd.useHostPID }}
       hostPID: true
-      {{- else -}}
-      {{- if .Values.datadog.dogstatsd.useHostPID }}
-      hostPID: {{ .Values.datadog.dogstatsd.useHostPID }}
-      {{- end }}
       {{- end }}
       {{- if .Values.agents.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
The enabling securityAgent.compliance but not useHostPID, it created an inconsistency where it would be enabled in the daemonset but not enabled in the SCC for OpenShift. The result was failed deployment in OpenShift.

Tested with OpenShift 4 on Azure (ARO).